### PR TITLE
Testing two new workflows

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,9 +1,8 @@
 name: publish package to test-pypi and pypi
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
@@ -22,12 +21,6 @@ jobs:
       - name: Build
         run: |
           python setup.py sdist bdist_wheel
-      - name: publish package to test-pypi
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.ref, '-rc')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
       - name: publish package to pypi
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && !contains(github.ref, '-rc')
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish_test_pypi.yml
+++ b/.github/workflows/publish_test_pypi.yml
@@ -1,0 +1,30 @@
+name: publish package to test-pypi
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-publish-pypi.txt
+      - name: Build
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: publish package to test-pypi
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.ref, '-rc')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: testing
 
 on: [push]
 


### PR DESCRIPTION
According to https://help.github.com/en/actions/reference/events-that-trigger-workflows, draft releases cannot trigger an action. Therefore I think it makes most sense to trigger test-pypi on merge, and pypi on release.